### PR TITLE
Vierte Koordinate benutzt Wert der Dritten

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
 				if(!time4){
 				time4 = 10;
 				}
-				arraywert = wert3.split(', ')
+				arraywert = wert4.split(', ')
 				lat4 = arraywert[0];
 				lon4 = arraywert[1];
 				wert5 = $('#LatLong5').val();
@@ -237,7 +237,7 @@
 				if(!time4){
 				time4 = 10;
 				}
-				arraywert = wert3.split(', ')
+				arraywert = wert4.split(', ')
 				lat4 = arraywert[0];
 				lon4 = arraywert[1];
 				wert5 = $('#LatLong5').val();


### PR DESCRIPTION
Hallo,

wir haben gestern in Ihrem Physikkurs bemerkt, dass es einen Bug im geolocation-converter Programm gibt. Dies war der Grund dafür, warum es schien, als ob GPS im Schulgebäude ausfallen würde, jedoch wird bei 5 oder 6 Koordinaten aufgrund eines Fehlers im Programm für sowohl den 3. als auch den 4. Wert im Diagramm die dritte Koordinate übernommen. Die vierte Koordinate wird also ignoriert und es wird zweimal die dritte angezeigt.

![image](https://github.com/dasbenjo/geolocation-converter/assets/66128192/9e60f6d8-06b6-45b6-a786-e78d5cbdb4d7)
Wie im Foto zu sehen ist das Diagramm trotz aufsteigender Koordinaten fehlerhaft.
Dies wird durch dieses Commit behoben.

Liebe Grüße
Dominik und Moritz aus Physik